### PR TITLE
test: add tests to check `WalletPersister` impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ wallet = ["bdk_wallet"]
 [dev-dependencies]
 anyhow = "1.0.98"
 bdk_testenv = { version = "0.13.0" }
+bdk_wallet = {version = "2.0.0", features = ["test-utils"]}
+assert_matches = "1.5.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 #![warn(missing_docs)]
 //! This module contains the crate's error type.
+use bdk_chain::bitcoin;
 use std::io::Error as IoError;
 
 #[derive(Debug, thiserror::Error)]
@@ -34,4 +35,8 @@ pub enum StoreError {
     /// [`BlockHash`]: <https://docs.rs/bitcoin/latest/bitcoin/struct.BlockHash.html>
     #[error("BlockHash deserialization error: {0}")]
     BlockHashFromSlice(#[from] bdk_chain::bitcoin::hashes::FromSliceError),
+    /// Error thrown when tx corresponding to txid is not found while persisting
+    /// anchors, last_seen, last_evicted or first_seen.
+    #[error("Tx corresponding to txid is missing")]
+    TxMissing(bitcoin::Txid),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@ const NETWORK: TableDefinition<&str, String> = TableDefinition::new("network");
 /// This is the primary struct of this crate. It holds the database corresponding to a wallet.
 /// It also holds the table names of redb tables which are specific to each wallet in a database
 /// file.
+#[derive(Debug)]
 pub struct Store {
     // We use a reference so as to avoid taking ownership of the Database, allowing other
     // applications to write to it. Arc is for thread safety.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -898,6 +898,20 @@ mod test {
     use bdk_testenv::{block_id, hash, utils};
 
     #[cfg(feature = "wallet")]
+    use bdk_wallet::{
+        KeychainKind, LoadError, LoadMismatch, LoadWithPersistError, Wallet,
+        bitcoin::{constants::ChainHash, key::Secp256k1},
+        descriptor::IntoWalletDescriptor,
+        test_utils::{
+            get_test_tr_single_sig_xprv, get_test_tr_single_sig_xprv_and_change_desc,
+            get_test_wpkh, insert_anchor, insert_tx,
+        },
+    };
+
+    #[cfg(feature = "wallet")]
+    use assert_matches::assert_matches;
+
+    #[cfg(feature = "wallet")]
     const DESCRIPTORS: [&str; 4] = [
         "tr([5940b9b9/86'/0'/0']tpubDDVNqmq75GNPWQ9UNKfP43UwjaHU4GYfoPavojQbfpyfZp2KetWgjGBRRAy4tYCrAA6SB11mhQAkqxjh1VtQHyKwT4oYxpwLaGHvoKmtxZf/1/*)#ypcpw2dr",
         "tr([5940b9b9/86'/0'/0']tpubDDVNqmq75GNPWQ9UNKfP43UwjaHU4GYfoPavojQbfpyfZp2KetWgjGBRRAy4tYCrAA6SB11mhQAkqxjh1VtQHyKwT4oYxpwLaGHvoKmtxZf/0/*)#44aqnlam",
@@ -2158,5 +2172,314 @@ mod test {
         let mut changeset_read = ChangeSet::default();
         store2.read_wallet(&mut changeset_read).unwrap();
         assert_eq!(changeset_read, changeset2);
+    }
+
+    #[cfg(feature = "wallet")]
+    #[test]
+    fn wallet_is_persisted() {
+        use bdk_chain::keychain_txout::DEFAULT_LOOKAHEAD;
+
+        let tmpfile = NamedTempFile::new().unwrap();
+        let db = Arc::new(create_db(tmpfile.path()));
+        let (external_desc, internal_desc) = get_test_tr_single_sig_xprv_and_change_desc();
+
+        // create new wallet
+        let wallet_spk_index = {
+            let mut store = create_test_store(db.clone(), "wallet");
+            let mut wallet = Wallet::create(external_desc, internal_desc)
+                .network(Network::Testnet)
+                .use_spk_cache(true)
+                .create_wallet(&mut store)
+                .expect("should create wallet");
+            wallet.reveal_next_address(KeychainKind::External);
+
+            // persist new wallet changes
+            assert!(
+                wallet.persist(&mut store).expect("should persist"),
+                "must write"
+            );
+            wallet.spk_index().clone()
+        };
+
+        // recover wallet
+        {
+            let mut store = create_test_store(db.clone(), "wallet");
+            let wallet = Wallet::load()
+                .descriptor(KeychainKind::External, Some(external_desc))
+                .descriptor(KeychainKind::Internal, Some(internal_desc))
+                .check_network(Network::Testnet)
+                .load_wallet(&mut store)
+                .expect("should load wallet")
+                .expect("wallet must exist");
+
+            assert_eq!(wallet.network(), Network::Testnet);
+            assert_eq!(
+                wallet.spk_index().keychains().collect::<Vec<_>>(),
+                wallet_spk_index.keychains().collect::<Vec<_>>()
+            );
+            assert_eq!(
+                wallet.spk_index().last_revealed_indices(),
+                wallet_spk_index.last_revealed_indices()
+            );
+            let secp = Secp256k1::new();
+            assert_eq!(
+                *wallet.public_descriptor(KeychainKind::External),
+                external_desc
+                    .into_wallet_descriptor(&secp, wallet.network())
+                    .unwrap()
+                    .0
+            );
+        }
+        // Test SPK cache
+        {
+            let mut store = create_test_store(db.clone(), "wallet");
+            let mut wallet = Wallet::load()
+                .check_network(Network::Testnet)
+                .use_spk_cache(true)
+                .load_wallet(&mut store)
+                .expect("should load wallet")
+                .expect("wallet must exist");
+
+            let external_did = wallet
+                .public_descriptor(KeychainKind::External)
+                .descriptor_id();
+            let internal_did = wallet
+                .public_descriptor(KeychainKind::Internal)
+                .descriptor_id();
+
+            assert!(wallet.staged().is_none());
+
+            let _addr = wallet.reveal_next_address(KeychainKind::External);
+            let cs = wallet.staged().expect("we should have staged a changeset");
+            assert!(!cs.indexer.spk_cache.is_empty(), "failed to cache spks");
+            assert_eq!(cs.indexer.spk_cache.len(), 2, "we persisted two keychains");
+            let spk_cache: &BTreeMap<u32, ScriptBuf> =
+                cs.indexer.spk_cache.get(&external_did).unwrap();
+            assert_eq!(spk_cache.len() as u32, 1 + 1 + DEFAULT_LOOKAHEAD);
+            assert_eq!(spk_cache.keys().last(), Some(&26));
+            let spk_cache = cs.indexer.spk_cache.get(&internal_did).unwrap();
+            assert_eq!(spk_cache.len() as u32, DEFAULT_LOOKAHEAD);
+            assert_eq!(spk_cache.keys().last(), Some(&24));
+            // Clear the stage
+            let _ = wallet.take_staged();
+            let _addr = wallet.reveal_next_address(KeychainKind::Internal);
+            let cs = wallet.staged().unwrap();
+            assert_eq!(cs.indexer.spk_cache.len(), 1);
+            let spk_cache = cs.indexer.spk_cache.get(&internal_did).unwrap();
+            assert_eq!(spk_cache.len(), 1);
+            assert_eq!(spk_cache.keys().next(), Some(&25));
+        }
+        // SPK cache requires load params
+        {
+            let mut store = create_test_store(db.clone(), "wallet");
+            let mut wallet = Wallet::load()
+                .check_network(Network::Testnet)
+                // .use_spk_cache(false)
+                .load_wallet(&mut store)
+                .expect("should load wallet")
+                .expect("wallet must exist");
+
+            let internal_did = wallet
+                .public_descriptor(KeychainKind::Internal)
+                .descriptor_id();
+
+            assert!(wallet.staged().is_none());
+
+            let _addr = wallet.reveal_next_address(KeychainKind::Internal);
+            let cs = wallet.staged().expect("we should have staged a changeset");
+            assert_eq!(cs.indexer.last_revealed.get(&internal_did), Some(&0));
+            assert!(
+                cs.indexer.spk_cache.is_empty(),
+                "we didn't set `use_spk_cache`"
+            );
+        }
+    }
+
+    #[cfg(feature = "wallet")]
+    #[test]
+    fn wallet_load_checks() {
+        let tmpfile = NamedTempFile::new().unwrap();
+        let db = Arc::new(create_db(tmpfile.path()));
+        let network = Network::Testnet;
+        let (external_desc, internal_desc) = get_test_tr_single_sig_xprv_and_change_desc();
+
+        // create new wallet
+
+        let _ = Wallet::create(external_desc, internal_desc)
+            .network(network)
+            .create_wallet(&mut create_test_store(db.clone(), "wallet"))
+            .expect("wallet should get created");
+
+        assert_matches!(
+            Wallet::load()
+                .check_network(Network::Regtest)
+                .load_wallet(&mut create_test_store(db.clone(), "wallet")),
+            Err(LoadWithPersistError::InvalidChangeSet(LoadError::Mismatch(
+                LoadMismatch::Network {
+                    loaded: Network::Testnet,
+                    expected: Network::Regtest,
+                }
+            ))),
+            "unexpected network check result: Regtest (check) is not Testnet (loaded)",
+        );
+
+        let mainnet_hash = BlockHash::from_byte_array(ChainHash::BITCOIN.to_bytes());
+        assert_matches!(
+            Wallet::load()
+                .check_genesis_hash(mainnet_hash)
+                .load_wallet(&mut create_test_store(db.clone(), "wallet")),
+            Err(LoadWithPersistError::InvalidChangeSet(LoadError::Mismatch(
+                LoadMismatch::Genesis { .. }
+            ))),
+            "unexpected genesis hash check result: mainnet hash (check) is not testnet hash (loaded)",
+        );
+        assert_matches!(
+            Wallet::load()
+                .descriptor(KeychainKind::External, Some(internal_desc))
+                .load_wallet(&mut create_test_store(db.clone(), "wallet")),
+            Err(LoadWithPersistError::InvalidChangeSet(LoadError::Mismatch(
+                LoadMismatch::Descriptor { .. }
+            ))),
+            "unexpected descriptors check result",
+        );
+        assert_matches!(
+            Wallet::load()
+                .descriptor(KeychainKind::External, Option::<&str>::None)
+                .load_wallet(&mut create_test_store(db.clone(), "wallet")),
+            Err(LoadWithPersistError::InvalidChangeSet(LoadError::Mismatch(
+                LoadMismatch::Descriptor { .. }
+            ))),
+            "unexpected descriptors check result",
+        );
+        // check setting keymaps
+        let (_, external_keymap) =
+            <Descriptor<DescriptorPublicKey>>::parse_descriptor(&Secp256k1::new(), external_desc)
+                .expect("failed to parse descriptor");
+        let (_, internal_keymap) =
+            <Descriptor<DescriptorPublicKey>>::parse_descriptor(&Secp256k1::new(), internal_desc)
+                .expect("failed to parse descriptor");
+        let wallet = Wallet::load()
+            .keymap(KeychainKind::External, external_keymap)
+            .keymap(KeychainKind::Internal, internal_keymap)
+            .load_wallet(&mut create_test_store(db.clone(), "wallet"))
+            .expect("db should not fail")
+            .expect("wallet was persisted");
+        for keychain in [KeychainKind::External, KeychainKind::Internal] {
+            let keymap = wallet.get_signers(keychain).as_key_map(wallet.secp_ctx());
+            assert!(
+                !keymap.is_empty(),
+                "load should populate keymap for keychain {keychain:?}"
+            );
+        }
+    }
+
+    #[cfg(feature = "wallet")]
+    #[test]
+    fn wallet_should_persist_anchors_and_recover() {
+        use bdk_chain::ChainPosition;
+        let tmpfile = NamedTempFile::new().unwrap();
+        let db = Arc::new(create_db(tmpfile.path()));
+        let mut store = create_test_store(db.clone(), "wallet");
+
+        let desc = get_test_tr_single_sig_xprv();
+        let mut wallet = Wallet::create_single(desc)
+            .network(Network::Testnet)
+            .create_wallet(&mut store)
+            .unwrap();
+
+        let small_output_tx = Transaction {
+            input: vec![],
+            output: vec![TxOut {
+                script_pubkey: wallet
+                    .next_unused_address(KeychainKind::External)
+                    .script_pubkey(),
+                value: Amount::from_sat(25_000),
+            }],
+            version: transaction::Version::non_standard(0),
+            lock_time: absolute::LockTime::ZERO,
+        };
+        let txid = small_output_tx.compute_txid();
+        insert_tx(&mut wallet, small_output_tx);
+        let expected_anchor = ConfirmationBlockTime {
+            block_id: wallet.latest_checkpoint().block_id(),
+            confirmation_time: 200,
+        };
+        insert_anchor(&mut wallet, txid, expected_anchor);
+        assert!(wallet.persist(&mut store).unwrap());
+
+        // should recover persisted wallet
+        let secp = wallet.secp_ctx();
+        let (_, keymap) = <Descriptor<DescriptorPublicKey>>::parse_descriptor(secp, desc).unwrap();
+        assert!(!keymap.is_empty());
+        let wallet = Wallet::load()
+            .descriptor(KeychainKind::External, Some(desc))
+            .extract_keys()
+            .load_wallet(&mut store)
+            .unwrap()
+            .expect("must have loaded changeset");
+        // stored anchor should be retrieved in the same condition it was persisted
+        if let ChainPosition::Confirmed {
+            anchor: obtained_anchor,
+            ..
+        } = wallet
+            .get_tx(txid)
+            .expect("should retrieve stored tx")
+            .chain_position
+        {
+            assert_eq!(obtained_anchor, expected_anchor)
+        } else {
+            panic!("Should have got ChainPosition::Confirmed)");
+        }
+    }
+
+    #[cfg(feature = "wallet")]
+    #[test]
+    fn single_descriptor_wallet_persist_and_recover() {
+        use bdk_chain::miniscript::Descriptor;
+        use bdk_chain::miniscript::DescriptorPublicKey;
+
+        let tmpfile = NamedTempFile::new().unwrap();
+        let db = Arc::new(create_db(tmpfile.path()));
+        let mut store = create_test_store(db.clone(), "wallet");
+
+        let desc = get_test_tr_single_sig_xprv();
+        let mut wallet = Wallet::create_single(desc)
+            .network(Network::Testnet)
+            .create_wallet(&mut store)
+            .unwrap();
+        let _ = wallet.reveal_addresses_to(KeychainKind::External, 2);
+        assert!(wallet.persist(&mut store).unwrap());
+
+        // should recover persisted wallet
+        let secp = wallet.secp_ctx();
+        let (_, keymap) = <Descriptor<DescriptorPublicKey>>::parse_descriptor(secp, desc).unwrap();
+        assert!(!keymap.is_empty());
+        let wallet = Wallet::load()
+            .descriptor(KeychainKind::External, Some(desc))
+            .extract_keys()
+            .load_wallet(&mut store)
+            .unwrap()
+            .expect("must have loaded changeset");
+        assert_eq!(wallet.derivation_index(KeychainKind::External), Some(2));
+        // should have private key
+        assert_eq!(
+            wallet.get_signers(KeychainKind::External).as_key_map(secp),
+            keymap,
+        );
+
+        // should error on wrong internal params
+        let desc = get_test_wpkh();
+        let (exp_desc, _) =
+            <Descriptor<DescriptorPublicKey>>::parse_descriptor(secp, desc).unwrap();
+        let err = Wallet::load()
+            .descriptor(KeychainKind::Internal, Some(desc))
+            .extract_keys()
+            .load_wallet(&mut store);
+        assert_matches!(
+            err,
+            Err(LoadWithPersistError::InvalidChangeSet(LoadError::Mismatch(LoadMismatch::Descriptor { keychain, loaded, expected })))
+            if keychain == KeychainKind::Internal && loaded.is_none() && expected == Some(exp_desc),
+            "single descriptor wallet should refuse change descriptor param"
+        );
     }
 }


### PR DESCRIPTION
Fixes #15 . Tests are stolen from [bdk_wallet](https://github.com/bitcoindevkit/bdk_wallet/blob/release/2.0/wallet/tests/persisted_wallet.rs) :sweat_smile: .