### PR TITLE
feat: check WalletPersister impl using bdk_wallet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 rust-version = "1.85.0"
 
 [dependencies]
-bdk_wallet = {version = "2.0.0", optional = true}
+bdk_wallet = {version = "2.3.0", optional = true}
 bdk_chain = {version = "0.23.0", features = ["serde"]}
 ciborium = "0.2.2"
 redb = "2.5.0"
@@ -23,6 +23,8 @@ wallet = ["bdk_wallet"]
 anyhow = "1.0.98"
 bdk_testenv = { version = "0.13.0" }
 tempfile = "3.20.0"
+bdk_wallet = {version = "2.3.0", features = ["test-utils"]}
+bdk_chain = {version = "0.23.0", features = ["serde"]}
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1956,4 +1956,15 @@ mod test {
         store2.read_wallet(&mut changeset_read).unwrap();
         assert_eq!(changeset_read, changeset2);
     }
+
+    #[cfg(feature = "wallet")]
+    #[test]
+    fn wallet_is_persisted() {
+        use bdk_wallet::persist_test_utils::persist_wallet_changeset;
+
+        persist_wallet_changeset("wallet.redb", |path| {
+            let db = redb::Database::create(path)?;
+            Ok(Store::new(Arc::new(db), "wallet".to_string())?)
+        });
+    }
 }


### PR DESCRIPTION
Fixes #15 
Used persist_test_utils in bdk_wallet to check the WalletPersister impl of `bdk_redb::Store`.